### PR TITLE
Implement use of WDC API to fetch observatory metadata 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ import 'leaflet/dist/leaflet.css';
 
 import React from 'react';
 import { HashRouter, Route, Link } from "react-router-dom";
-import { Navbar, Nav, Container, Row } from 'react-bootstrap';
+import { Navbar, Nav, Container, Row, Alert } from 'react-bootstrap';
 
 // Hooks
 import useMetaDataApi from './hooks/useMetaDataApi';
@@ -34,31 +34,89 @@ import getContacts from './utils/get-contacts'
 import getInstDetails from './utils/get-institutes'
 import getObsDetails from './utils/get-observatories'
 
-const App = () => {
-  const [ definitiveState ] = useMetaDataApi('https://wdcapi.bgs.ac.uk/metadata/intermagnet-definitive-catalogue');
-  const [ allMetadataState ] = useMetaDataApi('https://wdcapi.bgs.ac.uk/metadata/observatory-metadata');
+// hook to manage metadata loading
+const useAllMetadata = () => {
+  const [definitiveState] = useMetaDataApi('https://wdcapi.bgs.ac.uk/metadata/intermagnet-definitive-catalogue');
+  const [observatoryState] = useMetaDataApi('https://wdcapi.bgs.ac.uk/metadata/observatory-metadata?intermagnet=true&historical_instruments=false');
   
-  // Check if all data has loaded successfully
-  const isAllDataLoaded = !definitiveState.isLoading &&
-                          !allMetadataState.isLoading &&
-                          !definitiveState.isError &&
-                          !allMetadataState.isError &&
-                          definitiveState.data &&
-                          allMetadataState.data;
+  // Combine loading states
+  const isLoading = definitiveState.isLoading || observatoryState.isLoading;
+  const hasError = definitiveState.isError || observatoryState.isError;
+  const allDataLoaded = definitiveState.data && observatoryState.data && !isLoading && !hasError;
+  
+  // Process data when both API calls have completed successfully
+  const processedData = allDataLoaded
+  ? {
+      definitive: definitiveState.data,
+      institutes: getInstDetails(observatoryState),
+      observatories: getObsDetails(observatoryState),
+      contacts: getContacts(observatoryState)
+    }
+  : null;
+  
+  return {
+    isLoading,
+    hasError,
+    allDataLoaded,
+    processedData,
+    definitiveState,
+    observatoryState
+  };
+};
 
-  // Only process data if it's loaded
-  const observatoryInstitutes = isAllDataLoaded ? getInstDetails(allMetadataState) : [];
-  const observatoryDetails = isAllDataLoaded ? getObsDetails(allMetadataState) : [];
-  const observatoryContacts = isAllDataLoaded ? getContacts(allMetadataState) : [];
+const App = () => {
+
+  // get loading/error state using hook
+  const {
+    isLoading,
+    hasError,
+    allDataLoaded,
+    processedData,
+    definitiveState,
+    observatoryState
+  } = useAllMetadata();
+
+  // Error handling if API is down
+  if (hasError) {
+    return (
+      <HashRouter basename="/">
+        <Navbar bg="primary" variant="dark" expand="lg">
+          <Navbar.Brand href="https://intermagnet.github.io/">INTERMAGNET</Navbar.Brand>
+        </Navbar>
+        <Container className="mt-4">
+          <Alert variant="danger">
+            <Alert.Heading>Error Loading Data</Alert.Heading>
+            <p>
+              Failed to fetch data. Please try refreshing the page.
+            </p>
+            <p>
+              Metadata access: <a href="https://wdcapi.bgs.ac.uk/docs" target="_blank" rel="noopener noreferrer">https://wdcapi.bgs.ac.uk/docs</a>
+            </p>
+            <hr />
+            <div className="mb-0">
+              <ul className="list-disc ml-4">
+                {definitiveState.isError && <li>Definitive data catalogue failed to load</li>}
+                {observatoryState.isError && <li>Observatory metadata and contacts failed to load</li>}
+              </ul>
+            </div>
+          </Alert>
+        </Container>
+      </HashRouter>
+    );
+  }
 
   return (
     <HashRouter basename="/">
-      <Loader
-        contactsState={allMetadataState}
-        definitiveState={definitiveState}
-        institutesState={allMetadataState}
-        intermagnetState={allMetadataState}
-      />
+      {/* Show loading indicator while data is being fetched */}
+      {/* Using WDC API we have 2 loading states, not 4, but visually we can keep all 4*/}
+      {isLoading && (
+        <Loader
+          contactsState={observatoryState}
+          definitiveState={definitiveState}
+          institutesState={observatoryState}
+          intermagnetState={observatoryState}
+        />
+      )}
 
       <Navbar bg="primary" variant="dark" expand="lg">
         <Navbar.Brand href="https://intermagnet.github.io/">INTERMAGNET</Navbar.Brand>
@@ -73,13 +131,14 @@ const App = () => {
         </Navbar.Collapse>
       </Navbar>
 
-      {isAllDataLoaded && (
+      {/* Only render main content when all data is loaded */}
+      {allDataLoaded && processedData && (
         <Container fluid className='main-content'>
           <Row>
-            <ObservatoriesContext.Provider value={observatoryDetails}>
-              <InstitutesContext.Provider value={observatoryInstitutes}>
-                <ContactsContext.Provider value={observatoryContacts}>
-                  <DefinitiveContext.Provider value={definitiveState.data}>
+            <ObservatoriesContext.Provider value={processedData.observatories}>
+              <InstitutesContext.Provider value={processedData.institutes}>
+                <ContactsContext.Provider value={processedData.contacts}>
+                  <DefinitiveContext.Provider value={processedData.definitive}>
                     <Route exact path="/" component={ObservatoriesTable} />
                     <Route path="/map" component={ObservatoriesMap} />
                     <Route path="/imos" component={ObservatoriesTable} />

--- a/src/components/DefinitivesTable.js
+++ b/src/components/DefinitivesTable.js
@@ -82,7 +82,7 @@ const DefinitivesTable = (props) => {
   const defs = (definitives) ? definitives : [];
   const data = [];
   
-  defs.forEach( definitive => {
+  defs["intermagnet_catalogue"].forEach( definitive => {
     const year = definitive.id;
     definitive.observatories.forEach( obs => {
       data.push({
@@ -193,8 +193,10 @@ const DefinitivesTable = (props) => {
 };
 
 DefinitivesTable.propTypes = {
-  definitives: PropTypes.arrayOf(PropTypes.object),
-  setSelectedObservatories: PropTypes.func,
+  definitives: PropTypes.shape({
+    intermagnet_catalogue: PropTypes.array
+  }),
+  setSelectedObservatories: PropTypes.func
 };
 
 DefinitivesTable.defaultProps = {

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -13,7 +13,7 @@ const COMPLETED_COUNT = 4;
 
 /**
  * Loader text information
- * @param {object} props 
+ * @param {object} props
  */
 const LoaderText = (props) => {
   const {
@@ -86,15 +86,12 @@ const Loader = (props) => {
           isLoading={institutesState.isLoading} isError={institutesState.isError} />
         <LoaderText item='definitive information'
           isLoading={definitiveState.isLoading} isError={definitiveState.isError} />
-        <LoaderText item='intermanget observatory details'
+        <LoaderText item='intermagnet observatory details'
           isLoading={intermagnetState.isLoading} isError={intermagnetState.isError} />
       </Modal.Body>
     </Modal>
   )
 };
-
-
-
 
 const stateObject = {
   isError: PropTypes.bool.isRequired,

--- a/src/containers/DefinitivesTable.js
+++ b/src/containers/DefinitivesTable.js
@@ -24,7 +24,7 @@ const Definitives = () => {
           <Col sm={4}>
             <DefinitivesTable
               definitives={definitives}
-              setSelectedObservatories={setSelectedObservatories}  
+              setSelectedObservatories={setSelectedObservatories}
             />
           </Col>
           <Col sm={8}>

--- a/src/containers/InstitutesTable.js
+++ b/src/containers/InstitutesTable.js
@@ -3,32 +3,28 @@
  * @author Charles Blais, Natural Resources Canada <charles.blais@canada.ca>
  */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import { Col } from 'react-bootstrap';
 
-// Hooks
-import InstitutesContext from '../contexts/institutes-context';
+// Components
+import InstitutesTable from '../components/InstitutesTable';
 
 // Contexts
-import InstitutesTable from '../components/InstitutesTable';
+import InstitutesContext from '../contexts/institutes-context';
 import ObservatoriesContext from '../contexts/observatories-context';
 
 const Institutes = () => {
+  const institutes = useContext(InstitutesContext);
+  const observatories = useContext(ObservatoriesContext);
+
   return (
     <Col sm={12}>
-      <ObservatoriesContext>
-        { observatories => (
-          <InstitutesContext.Consumer>
-            { institutes => (
-              <InstitutesTable
-                institutes={(institutes) ? institutes : []} 
-                observatories={(observatories) ? observatories : []} />
-            )}
-          </InstitutesContext.Consumer>
-        )}
-      </ObservatoriesContext>
+      <InstitutesTable
+        institutes={institutes || []}
+        observatories={observatories || []}
+      />
     </Col>
-  )
-}
+  );
+};
 
 export default Institutes;

--- a/src/utils/get-contacts.js
+++ b/src/utils/get-contacts.js
@@ -1,0 +1,37 @@
+const getContacts = function getContacts(state) {
+	const data = state.data.data;
+	const uniqueContacts = new Set();
+	const result = {};
+
+	data
+		.filter(entry =>
+			Array.isArray(entry.intermagnet) &&
+			entry.intermagnet.length > 0 &&
+			entry.institutes.length > 0
+		)
+		.forEach(entry => {
+			entry.persons.forEach(person => {
+				const nameID = `${person.family_name}_${person.given_name}`;
+				if (!uniqueContacts.has(nameID)) {
+					uniqueContacts.add(nameID);
+
+					const nameParts = [person.title, person.given_name, person.family_name].filter(Boolean);
+					const name = nameParts.join(' ');
+					const emails = [
+						...(person.email2 ? [person.email2] : []),
+						person.email
+					];
+
+					result[nameID] = {
+						addresses: [],
+						name,
+						emails
+					};
+				}
+			});
+		});
+
+	return result;
+}
+
+export default getContacts

--- a/src/utils/get-contacts.js
+++ b/src/utils/get-contacts.js
@@ -1,37 +1,65 @@
+/**
+ * Extracts and transforms contact details from WDC API response
+ * @param {Object} state - Application state containing observatory data
+ * @author Adam Emsley, British Geological Survey <adam.emsley@bgs.ac.uk>
+**/
 const getContacts = function getContacts(state) {
+
+	// get data
 	const data = state.data.data;
 	const uniqueContacts = new Set();
 	const result = {};
 
 	data
-		.filter(entry =>
-			Array.isArray(entry.intermagnet) &&
-			entry.intermagnet.length > 0 &&
-			entry.institutes.length > 0
-		)
 		.forEach(entry => {
 			entry.persons.forEach(person => {
 				const nameID = `${person.family_name}_${person.given_name}`;
 				if (!uniqueContacts.has(nameID)) {
 					uniqueContacts.add(nameID);
 
+					// user boolean filter to get full name
 					const nameParts = [person.title, person.given_name, person.family_name].filter(Boolean);
 					const name = nameParts.join(' ');
 					const emails = [
+						...(person.email ? [person.email] : []),
 						...(person.email2 ? [person.email2] : []),
-						person.email
+
+					];
+
+					const tel1 = person.phone;
+					const tel2 = person.phone2;
+					const fax = person.fax;
+					
+					// use spread operator to add fields that are in database
+					const address = [
+						{
+							...(person.address1 && { address1: person.address1 }),
+							...(person.address2 && { address2: person.address2 }),
+							...(person.address3 && { address3: person.address3 }),
+							...(person.address4 && { address4: person.address4 }),
+							...(person.address5 && { address5: person.address5 }),
+							...(person.city && { city: person.city }),
+							...(person.state && { state: person.state }),
+							...(person.lang && { lang: person.lang }),
+							...(person.postcode && { postcode: person.postcode }),
+							...(person.country && { country: person.country }),
+						}
 					];
 
 					result[nameID] = {
-						addresses: [],
-						name,
-						emails
+						"addresses": address,
+						"name": name,
+						"emails": emails,
+						...(tel1 != null && { "tel": tel1 }),
+						...(tel2 != null && { "tel2": tel2 }),
+						"fax": fax
 					};
 				}
 			});
 		});
-
+	
 	return result;
 }
 
-export default getContacts
+// export
+export default getContacts;

--- a/src/utils/get-institutes.js
+++ b/src/utils/get-institutes.js
@@ -1,0 +1,45 @@
+const getInstDetails =  function getInstDetails(state) {
+	const data = state.data.data;
+	const uniqueInstitutes = new Set();
+
+	const result = [];
+
+	data
+		.filter(entry =>
+			Array.isArray(entry.intermagnet) &&
+			entry.intermagnet.length > 0 &&
+			!entry.intermagnet[0]['member_to'] &&
+			entry.institutes.length > 0
+		)
+		.forEach(entry => {
+			const address = entry.address && entry.address[0];
+
+			const rawCountry =
+				(address && address.country) ||
+				(entry.institutes[0] && entry.institutes[0].country) ||
+				'';
+
+			const match = rawCountry.match(/\((\w+)\)$/);
+			const countryCode = match ? match[1] : '';
+
+			entry.institutes.forEach(institute => {
+				const name = institute.institute_name;
+				const abbr = institute.abbreviation;
+				const link = institute.institute_url;
+
+				if (!uniqueInstitutes.has(name)) {
+					uniqueInstitutes.add(name);
+					result.push({
+						id: abbr,
+						country: countryCode,
+						names: [{ abbr, name }],
+						links: link ? [{ link }] : []
+					});
+				}
+			});
+		});
+
+	return result;
+}
+
+export default getInstDetails

--- a/src/utils/get-institutes.js
+++ b/src/utils/get-institutes.js
@@ -1,13 +1,20 @@
+/**
+ * Extracts and transforms institute details from WDC API response
+ * @param {Object} state - Application state containing observatory data
+ * @author Adam Emsley, British Geological Survey <adam.emsley@bgs.ac.uk>
+**/
 const getInstDetails =  function getInstDetails(state) {
+
+	// get data from JSON
 	const data = state.data.data;
 	const uniqueInstitutes = new Set();
 
 	const result = [];
 
+	// loop over observatories
 	data
+		// filter to get currently open intermagnet observatories
 		.filter(entry =>
-			Array.isArray(entry.intermagnet) &&
-			entry.intermagnet.length > 0 &&
 			!entry.intermagnet[0]['member_to'] &&
 			entry.institutes.length > 0
 		)
@@ -27,6 +34,7 @@ const getInstDetails =  function getInstDetails(state) {
 				const abbr = institute.abbreviation;
 				const link = institute.institute_url;
 
+				// push required structure
 				if (!uniqueInstitutes.has(name)) {
 					uniqueInstitutes.add(name);
 					result.push({
@@ -38,8 +46,9 @@ const getInstDetails =  function getInstDetails(state) {
 				}
 			});
 		});
-
+	
 	return result;
 }
 
-export default getInstDetails
+// export
+export default getInstDetails;

--- a/src/utils/get-observatories.js
+++ b/src/utils/get-observatories.js
@@ -1,0 +1,87 @@
+const getObsDetails = function getObsDetails(state) {
+	const data = state.data.data || [];
+	const result = [];
+
+	data.forEach(entry => {
+		const {
+			observatory_iaga_code: iaga,
+			attributes,
+			address = [],
+			instruments = [],
+			persons = [],
+			intermagnet = [],
+			institutes = [],
+			locations = []
+		} = entry;
+
+		const inter = intermagnet[0];
+		if (!inter) return;
+
+		let openClosed = 'imo';
+		if (inter.member_to) {
+			openClosed = 'closed';
+		}
+
+		const location = locations[0] || {};
+		const lat = parseFloat(location.latitude);
+		const lon = parseFloat(location.longitude);
+		const elevation = parseFloat(location.elevation);
+		const latitude_region = lat >= 0 ? 'NH' : 'SH';
+
+		const orientations = Array.from(
+			new Set(instruments.map(inst => inst.orientation).filter(Boolean))
+		).join('|');
+
+		const gin = inter.intermagnet_gin_code || undefined;
+		const communication = inter.gin_comms || undefined;
+		const publication = [inter.plot_delay, "source", "delay"] || undefined;
+
+		const contacts = persons.map(p =>
+			`${p.family_name}_${p.given_name}`.replace(/\s+/g, '')
+		);
+
+		const instruments_ml = [];
+		const lines = instruments
+			.map(inst => inst.instrument_name && inst.instrument_name.trim())
+			.filter(Boolean);
+
+		if (lines.length) {
+			instruments_ml.push({ lang: 'en', lines });
+		} else {
+			instruments_ml.push({});
+		}
+
+		let country = '';
+		if (address.length > 0 && address[0].country) {
+			const match = address[0].country.match(/\((\w+)\)/);
+			if (match && match[1]) {
+				country = match[1].toLowerCase();
+			}
+		}
+
+		result.push({
+			id: iaga,
+			iaga,
+			name: attributes.name,
+			elevation,
+			region: location.region || '',
+			gin,
+			communication,
+			institutes: institutes.map(inst => inst.abbreviation).filter(Boolean),
+			latitude: lat,
+			latitude_region,
+			longitude: lon,
+			contacts,
+			orientation: orientations || undefined,
+			publication: publication || undefined,
+			status: openClosed,
+			instruments_ml,
+			country
+		});
+	});
+
+	return result;
+}
+
+
+export default getObsDetails


### PR DESCRIPTION
## Summary
Currently the metadata is supplied by static files. This pull request allows dynamic database calls to be implemented, by making use of the World Data Centre (WDC) API: https://wdcapi.bgs.ac.uk/docs. I believe after testing, that the metadata supplied matches the existing files, but this may need someone else to verify for full confidence. An error alert is also added if API calls fail.

### Related Issues
- This addresses issue #39.
- An historical instrument flag is used to also address issue #40.

### Changes
- Metadata is fetched from: https://wdcapi.bgs.ac.uk/metadata/observatory-metadata?intermagnet=true&historical_instruments=false
- INTERMAGNET definitive catalogue is fetched from: https://wdcapi.bgs.ac.uk/metadata/intermagnet-definitive-catalogue
- `/src/utils/` added, which contains scripts to parse WDC response and re-structure into format needed for the application
- I additionally added an error alert modal if the API calls were to fail, which states which metadata could not be fetched, and shows the user where the metadata is sourced (i.e. the WDC API). 


### Notes
The loading statuses are left as 4 separate loaders i.e.:

`contactsState={observatoryState}`
`definitiveState={definitiveState}`
`institutesState={observatoryState}`
`intermagnetState={observatoryState}`

Although now instead of 4 URLs, we actually only fetch 2.  Thus, we only actually now track 2 states: `observatoryState` (which waits for HTTP fetch AND parsing of the response into correct JSON structures to complete) and `definitiveState`. 

Alternatively, we could reduce this to just 2 loaders - although the `observatoryState` does include the individual processing for each section.
